### PR TITLE
Refine generics in Option and Either

### DIFF
--- a/src/main/kotlin/org/funktionale/either/LeftProjection.kt
+++ b/src/main/kotlin/org/funktionale/either/LeftProjection.kt
@@ -29,7 +29,7 @@ import java.util.*
  * Date: 17/05/13
  * Time: 20:20
  */
-class LeftProjection<out L, out R>(val e: Either<L, R>) {
+class LeftProjection<out L : Any, out R : Any>(val e: Either<L, R>) {
 
     fun get(): L = when (e) {
         is Left -> e.l
@@ -49,7 +49,7 @@ class LeftProjection<out L, out R>(val e: Either<L, R>) {
     }
 
 
-    fun <X> map(f: (L) -> X): Either<X, R> = flatMap { Left<X, R>(f(it)) }
+    fun <X : Any> map(f: (L) -> X): Either<X, R> = flatMap { Left<X, R>(f(it)) }
 
     fun filter(predicate: (L) -> Boolean): Option<Either<L, R>> = when (e) {
         is Left -> {
@@ -74,14 +74,14 @@ class LeftProjection<out L, out R>(val e: Either<L, R>) {
 
 }
 
-fun <L, R, X> LeftProjection<L, R>.flatMap(f: (L) -> Either<X, R>): Either<X, R> = when (e) {
+fun <L : Any, R : Any, X : Any> LeftProjection<L, R>.flatMap(f: (L) -> Either<X, R>): Either<X, R> = when (e) {
     is Left -> f(e.l)
     is Right -> Right(e.r)
 }
 
-fun <L, R, X, Y> LeftProjection<L, R>.map(x: Either<X, R>, f: (L, X) -> Y): Either<Y, R> = flatMap { l -> x.left().map { xx -> f(l, xx) } }
+fun <L : Any, R : Any, X : Any, Y : Any> LeftProjection<L, R>.map(x: Either<X, R>, f: (L, X) -> Y): Either<Y, R> = flatMap { l -> x.left().map { xx -> f(l, xx) } }
 
-fun <R, L> LeftProjection<L, R>.getOrElse(default: () -> L): L = when (e) {
+fun <L : Any, R : Any> LeftProjection<L, R>.getOrElse(default: () -> L): L = when (e) {
     is Left -> e.l
     is Right -> default()
 }

--- a/src/main/kotlin/org/funktionale/either/RightProjection.kt
+++ b/src/main/kotlin/org/funktionale/either/RightProjection.kt
@@ -29,7 +29,7 @@ import java.util.*
  * Date: 17/05/13
  * Time: 20:20
  */
-class RightProjection<out L, out R>(val e: Either<L, R>) {
+class RightProjection<out L : Any, out R : Any>(val e: Either<L, R>) {
 
     fun get(): R = when (e) {
         is Right -> e.r
@@ -48,7 +48,7 @@ class RightProjection<out L, out R>(val e: Either<L, R>) {
         is Left -> false
     }
 
-    fun<X> map(f: (R) -> X): Either<L, X> = flatMap { Right<L, X>(f(it)) }
+    fun <X : Any> map(f: (R) -> X): Either<L, X> = flatMap { Right<L, X>(f(it)) }
 
     fun filter(predicate: (R) -> Boolean): Option<Either<L, R>> = when (e) {
         is Right -> {
@@ -73,15 +73,15 @@ class RightProjection<out L, out R>(val e: Either<L, R>) {
 
 }
 
-fun<L, R> RightProjection<L, R>.getOrElse(default: () -> R): R = when (e) {
+fun <L : Any, R : Any> RightProjection<L, R>.getOrElse(default: () -> R): R = when (e) {
     is Right -> e.r
     is Left -> default()
 }
 
-fun<X, L, R> RightProjection<L, R>.flatMap(f: (R) -> Either<L, X>): Either<L, X> = when (e) {
+fun <X : Any, L : Any, R : Any> RightProjection<L, R>.flatMap(f: (R) -> Either<L, X>): Either<L, X> = when (e) {
     is Left -> Left(e.l)
     is Right -> f(e.r)
 }
 
 
-fun<L, R, X, Y> RightProjection<L, R>.map(x: Either<L, X>, f: (R, X) -> Y): Either<L, Y> = flatMap { r -> x.right().map { xx -> f(r, xx) } }
+fun <L : Any, R : Any, X : Any, Y : Any> RightProjection<L, R>.map(x: Either<L, X>, f: (R, X) -> Y): Either<L, Y> = flatMap { r -> x.right().map { xx -> f(r, xx) } }

--- a/src/main/kotlin/org/funktionale/memoization/namespace.kt
+++ b/src/main/kotlin/org/funktionale/memoization/namespace.kt
@@ -26,154 +26,154 @@ import java.util.concurrent.ConcurrentHashMap
  * Time: 9:03 PM
  */
 
-fun <P1, R> ((P1) -> R).memoize(): (P1) -> R {
+fun <P1, R : Any> ((P1) -> R).memoize(): (P1) -> R {
     return object : (P1) -> R {
         private val m = MemoizedHandler<((P1) -> R), MemoizeKey1<P1, R>, R>(this@memoize)
         override fun invoke(p1: P1) = m(MemoizeKey1(p1))
     }
 }
 
-fun <P1, P2, R> ((P1, P2) -> R).memoize(): (P1, P2) -> R {
+fun <P1, P2, R : Any> ((P1, P2) -> R).memoize(): (P1, P2) -> R {
     return object : (P1, P2) -> R {
         private val m = MemoizedHandler<((P1, P2) -> R), MemoizeKey2<P1, P2, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2) = m(MemoizeKey2(p1, p2))
     }
 }
 
-fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(): (P1, P2, P3) -> R {
+fun <P1, P2, P3, R : Any> ((P1, P2, P3) -> R).memoize(): (P1, P2, P3) -> R {
     return object : (P1, P2, P3) -> R {
         private val m = MemoizedHandler<((P1, P2, P3) -> R), MemoizeKey3<P1, P2, P3, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3) = m(MemoizeKey3(p1, p2, p3))
     }
 }
 
-fun <P1, P2, P3, P4, R> ((P1, P2, P3, P4) -> R).memoize(): (P1, P2, P3, P4) -> R {
+fun <P1, P2, P3, P4, R : Any> ((P1, P2, P3, P4) -> R).memoize(): (P1, P2, P3, P4) -> R {
     return object : (P1, P2, P3, P4) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4) -> R), MemoizeKey4<P1, P2, P3, P4, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4) = m(MemoizeKey4(p1, p2, p3, p4))
     }
 }
 
-fun <P1, P2, P3, P4, P5, R> ((P1, P2, P3, P4, P5) -> R).memoize(): (P1, P2, P3, P4, P5) -> R {
+fun <P1, P2, P3, P4, P5, R : Any> ((P1, P2, P3, P4, P5) -> R).memoize(): (P1, P2, P3, P4, P5) -> R {
     return object : (P1, P2, P3, P4, P5) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5) -> R), MemoizeKey5<P1, P2, P3, P4, P5, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) = m(MemoizeKey5(p1, p2, p3, p4, p5))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, R> ((P1, P2, P3, P4, P5, P6) -> R).memoize(): (P1, P2, P3, P4, P5, P6) -> R {
+fun <P1, P2, P3, P4, P5, P6, R : Any> ((P1, P2, P3, P4, P5, P6) -> R).memoize(): (P1, P2, P3, P4, P5, P6) -> R {
     return object : (P1, P2, P3, P4, P5, P6) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6) -> R), MemoizeKey6<P1, P2, P3, P4, P5, P6, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) = m(MemoizeKey6(p1, p2, p3, p4, p5, p6))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, R> ((P1, P2, P3, P4, P5, P6, P7) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, R : Any> ((P1, P2, P3, P4, P5, P6, P7) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7) -> R), MemoizeKey7<P1, P2, P3, P4, P5, P6, P7, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) = m(MemoizeKey7(p1, p2, p3, p4, p5, p6, p7))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, R> ((P1, P2, P3, P4, P5, P6, P7, P8) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8) -> R), MemoizeKey8<P1, P2, P3, P4, P5, P6, P7, P8, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8) = m(MemoizeKey8(p1, p2, p3, p4, p5, p6, p7, p8))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R), MemoizeKey9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9) = m(MemoizeKey9(p1, p2, p3, p4, p5, p6, p7, p8, p9))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R), MemoizeKey10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10) = m(MemoizeKey10(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R), MemoizeKey11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11) = m(MemoizeKey11(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R), MemoizeKey12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12) = m(MemoizeKey12(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R), MemoizeKey13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13) = m(MemoizeKey13(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R), MemoizeKey14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14) = m(MemoizeKey14(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R), MemoizeKey15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15) = m(MemoizeKey15(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R), MemoizeKey16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16) = m(MemoizeKey16(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R), MemoizeKey17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17) = m(MemoizeKey17(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R), MemoizeKey18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18) = m(MemoizeKey18(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R), MemoizeKey19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19) = m(MemoizeKey19(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R), MemoizeKey20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19, p20: P20) = m(MemoizeKey20(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R), MemoizeKey21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19, p20: P20, p21: P21) = m(MemoizeKey21(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21))
     }
 }
 
-fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22, R> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R {
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22, R : Any> ((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R).memoize(): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R {
     return object : (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R {
         private val m = MemoizedHandler<((P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R), MemoizeKey22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22, R>, R>(this@memoize)
         override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19, p20: P20, p21: P21, p22: P22) = m(MemoizeKey22(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22))
@@ -272,7 +272,7 @@ private data class MemoizeKey22<out P1, out P2, out P3, out P4, out P5, out P6, 
     override fun invoke(f: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R) = f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22)
 }
 
-private class MemoizedHandler<F, in K : MemoizedCall<F, R>, R>(val f: F) {
+private class MemoizedHandler<F, in K : MemoizedCall<F, R>, R : Any>(val f: F) {
     private val m = ConcurrentHashMap<K, R>()
     operator fun invoke(k: K): R {
         return m[k].toOption().fold({

--- a/src/main/kotlin/org/funktionale/option/Option.kt
+++ b/src/main/kotlin/org/funktionale/option/Option.kt
@@ -33,8 +33,7 @@ import java.util.*
  * Date: 17/05/13
  * Time: 12:53
  */
-@Suppress("BASE_WITH_NULLABLE_UPPER_BOUND")
-sealed class Option<out T> {
+sealed class Option<out T : Any> {
     abstract fun isEmpty(): Boolean
 
     fun nonEmpty(): Boolean = isDefined()
@@ -49,25 +48,25 @@ sealed class Option<out T> {
         get()
     }
 
-    inline fun <R> map(f: (T) -> R): Option<R> = if (isEmpty()) {
+    inline fun <R : Any> map(f: (T) -> R): Option<R> = if (isEmpty()) {
         None
     } else {
         Some(f(get()))
     }
 
-    inline fun <P1, R> map(p1: Option<P1>, f: (T, P1) -> R): Option<R> = if (isEmpty()) {
+    inline fun <P1 : Any, R : Any> map(p1: Option<P1>, f: (T, P1) -> R): Option<R> = if (isEmpty()) {
         None
     } else {
         p1.map { pp1 -> f(get(), pp1) }
     }
 
-    inline fun <R> fold(ifEmpty: () -> R, f: (T) -> R): R = if (isEmpty()) {
+    inline fun <R : Any?> fold(ifEmpty: () -> R, f: (T) -> R): R = if (isEmpty()) {
         ifEmpty()
     } else {
         f(get())
     }
 
-    inline fun <R> flatMap(f: (T) -> Option<R>): Option<R> = if (isEmpty()) {
+    inline fun <R : Any> flatMap(f: (T) -> Option<R>): Option<R> = if (isEmpty()) {
         None
     } else {
         f(get())
@@ -99,26 +98,26 @@ sealed class Option<out T> {
     }
 
     @Deprecated("Use toEitherRight", ReplaceWith("toEitherRight(left)"))
-    inline fun <X> toRight(left: () -> X): Either<X, T> = toEitherRight(left)
+    inline fun <X : Any> toRight(left: () -> X): Either<X, T> = toEitherRight(left)
 
-    inline fun <X> toEitherRight(left: () -> X): Either<X, T> = if (isEmpty()) {
+    inline fun <X : Any> toEitherRight(left: () -> X): Either<X, T> = if (isEmpty()) {
         Left(left())
     } else {
         Right(get())
     }
 
-    inline fun <X> toDisjunctionRight(left: () -> X): Disjunction<X, T> = toEitherRight(left).toDisjunction()
+    inline fun <X : Any> toDisjunctionRight(left: () -> X): Disjunction<X, T> = toEitherRight(left).toDisjunction()
 
     @Deprecated("use toEitherLeft", ReplaceWith("toEitherLeft(right)"))
-    inline fun <X> toLeft(right: () -> X): Either<T, X> = toEitherLeft(right)
+    inline fun <X : Any> toLeft(right: () -> X): Either<T, X> = toEitherLeft(right)
 
-    inline fun <X> toEitherLeft(right: () -> X): Either<T, X> = if (isEmpty()) {
+    inline fun <X : Any> toEitherLeft(right: () -> X): Either<T, X> = if (isEmpty()) {
         Right(right())
     } else {
         Left(get())
     }
 
-    inline fun <X> toDisjunctionLeft(right: () -> X): Disjunction<T, X> = toEitherLeft(right).toDisjunction()
+    inline fun <X : Any> toDisjunctionLeft(right: () -> X): Disjunction<T, X> = toEitherLeft(right).toDisjunction()
 
     object None : Option<Nothing>() {
         override fun get() = throw NoSuchElementException("None.get")
@@ -133,54 +132,54 @@ sealed class Option<out T> {
         override fun hashCode(): Int = Integer.MAX_VALUE
     }
 
-    class Some<out T>(val t: T) : Option<T>() {
+    class Some<out T : Any>(val t: T) : Option<T>() {
         override fun get() = t
 
         override fun isEmpty() = false
 
         override fun equals(other: Any?): Boolean = when (other) {
-            is Some<*> -> t!!.equals(other.get())
+            is Some<*> -> t.equals(other.get())
             is None -> false
             else -> false
         }
 
-        override fun hashCode(): Int = t!!.hashCode() + 17
+        override fun hashCode(): Int = t.hashCode() + 17
 
         override fun toString(): String = "Some<$t>"
     }
 }
 
-fun <T> Option<T>.getOrElse(default: () -> T): T = if (isEmpty()) {
+fun <T : Any> Option<T>.getOrElse(default: () -> T): T = if (isEmpty()) {
     default()
 } else {
     get()
 }
 
-fun <T> Option<T>.orElse(alternative: () -> Option<T>): Option<T> = if (isEmpty()) {
+fun <T : Any> Option<T>.orElse(alternative: () -> Option<T>): Option<T> = if (isEmpty()) {
     alternative()
 } else {
     this
 }
 
-@Suppress("BASE_WITH_NULLABLE_UPPER_BOUND") fun <T> T?.toOption(): Option<T> = if (this != null) {
+fun <T : Any> T?.toOption(): Option<T> = if (this != null) {
     Some(this)
 } else {
     None
 }
 
-inline fun <T> optionTry(body: () -> T): Option<T> = try {
+inline fun <T : Any> optionTry(body: () -> T): Option<T> = try {
     Some(body())
 } catch(e: Exception) {
     None
 }
 
-val <K, V> Map<K, V>.option: GetterOperation<K, Option<V>>
+val <K : Any?, V : Any> Map<K, V?>.option: GetterOperation<K, Option<V>>
     get () {
         return GetterOperationImpl { k -> this[k].toOption() }
     }
 
 
-fun <T> Array<out T>.firstOption(): Option<T> {
+fun <T : Any> Array<out T?>.firstOption(): Option<T> {
     return firstOrNull().toOption()
 }
 
@@ -219,15 +218,15 @@ fun ShortArray.firstOption(): Option<Short> {
     return firstOrNull().toOption()
 }
 
-fun <T> Iterable<T>.firstOption(): Option<T> {
+fun <T : Any> Iterable<T?>.firstOption(): Option<T> {
     return firstOrNull().toOption()
 }
 
-fun <T> List<T>.firstOption(): Option<T> {
+fun <T : Any> List<T?>.firstOption(): Option<T> {
     return firstOrNull().toOption()
 }
 
-fun <T> Sequence<T>.firstOption(): Option<T> {
+fun <T : Any> Sequence<T?>.firstOption(): Option<T> {
     return firstOrNull().toOption()
 }
 
@@ -236,8 +235,8 @@ fun String.firstOption(): Option<Char> {
     return firstOrNull().toOption()
 }
 
-inline fun <T> Array<out T>.firstOption(predicate: (T) -> Boolean): Option<T> {
-    return firstOrNull(predicate).toOption()
+inline fun <T : Any> Array<out T?>.firstOption(predicate: (T) -> Boolean): Option<T> {
+    return firstOrNull(predicate.mapNullable()).toOption()
 }
 
 inline fun BooleanArray.firstOption(predicate: (Boolean) -> Boolean): Option<Boolean> {
@@ -272,37 +271,40 @@ inline fun ShortArray.firstOption(predicate: (Short) -> Boolean): Option<Short> 
     return firstOrNull(predicate).toOption()
 }
 
-inline fun <T> Iterable<T>.firstOption(predicate: (T) -> Boolean): Option<T> {
-    return firstOrNull(predicate).toOption()
+inline fun <T : Any> Iterable<T?>.firstOption(predicate: (T) -> Boolean): Option<T> {
+    return firstOrNull(predicate.mapNullable()).toOption()
 }
 
-inline fun <T> Sequence<T>.firstOption(predicate: (T) -> Boolean): Option<T> {
-    return firstOrNull(predicate).toOption()
+inline fun <T : Any> Sequence<T?>.firstOption(predicate: (T) -> Boolean): Option<T> {
+    return firstOrNull(predicate.mapNullable()).toOption()
 }
-
 
 inline fun String.firstOption(predicate: (Char) -> Boolean): Option<Char> {
     return firstOrNull(predicate).toOption()
 }
 
-@Deprecated("Use optionTraverse", ReplaceWith("optionTraverse(f)"))
-fun <T, R> List<T>.traverse(f: (T) -> Option<R>) = optionTraverse(f)
+inline fun <T : Any> ((T) -> Boolean).mapNullable(): (T?) -> Boolean {
+    return { it?.let { this@mapNullable(it) } ?: false }
+}
 
-fun <T, R> List<T>.optionTraverse(f: (T) -> Option<R>): Option<List<R>> = foldRight(Some(emptyList())) { i: T, accumulator: Option<List<R>> ->
+@Deprecated("Use optionTraverse", ReplaceWith("optionTraverse(f)"))
+fun <T : Any?, R : Any> List<T>.traverse(f: (T) -> Option<R>) = optionTraverse(f)
+
+fun <T : Any?, R : Any> List<T>.optionTraverse(f: (T) -> Option<R>): Option<List<R>> = foldRight(Some(emptyList())) { i: T, accumulator: Option<List<R>> ->
     f(i).map(accumulator) { head: R, tail: List<R> ->
         head prependTo tail
     }
 }
 
 @Deprecated("Use optionSequential", ReplaceWith("optionSequential()"))
-fun <T> List<Option<T>>.sequential(): Option<List<T>> = optionSequential()
+fun <T : Any> List<Option<T>>.sequential(): Option<List<T>> = optionSequential()
 
-fun <T> List<Option<T>>.optionSequential(): Option<List<T>> = optionTraverse { it }
+fun <T : Any> List<Option<T>>.optionSequential(): Option<List<T>> = optionTraverse { it }
 
-fun <T> List<Option<T>>.flatten(): List<T> {
+fun <T : Any> List<Option<T>>.flatten(): List<T> {
     return filter { it.isDefined() }.map { it.get() }
 }
 
-fun <P1, R> Function1<P1, R>.optionLift(): (Option<P1>) -> Option<R> {
+fun <P1 : Any, R : Any> Function1<P1, R>.optionLift(): (Option<P1>) -> Option<R> {
     return { it.map(this) }
 }


### PR DESCRIPTION
### Description

Better handle Option and Either generics. The default upper bounds in Kotlin, if not specified, is Any? -> [https://kotlinlang.org/docs/reference/generics.html#upper-bounds (https://kotlinlang.org/docs/reference/generics.html#upper-bounds).

Without these changes, it is currently legal to have a nullable option value:

``` kotlin
fun getNull(): Option<String?> = Option.Some(null) 
```
#### Examples

``` kotlin
    class Value<out T>(val value: T) /* i.e. NullableValue<out T : Any?> */ {
        override fun hashCode(): Int = value!!.hashCode() // must account for possibly null value (!! operator)
    }

    class NonNullValue<out T : Any>(val value: T) {
        override fun hashCode(): Int = value.hashCode() // value is not null, no need for !!
    }

    @Test fun generics() {
        // Legal to use 'String?' instead of 'String'
        val nullValue: Value<String?> = Value(null)

        // Compile error for nullable generic type
//        val nonNullValue: NonNullValue<String?>

        val nonNullValue: NonNullValue<String>
        nonNullValue = NonNullValue("non-null")

        assertEquals("default", nullValue.value ?: "default")
        assertEquals("non-null", nonNullValue.value ?: "default")
    }
```
