### PR TITLE
Helper constructors for Disjunction and Either

### DIFF
--- a/src/main/kotlin/org/funktionale/either/Disjunction.kt
+++ b/src/main/kotlin/org/funktionale/either/Disjunction.kt
@@ -29,6 +29,11 @@ import java.util.*
  */
 sealed class Disjunction<out L, out R> : EitherLike {
 
+    companion object {
+        fun <L> left(left: L): Disjunction<L, Nothing> = Left(left)
+        fun <R> right(right: R): Disjunction<Nothing, R> = Right(right)
+    }
+
     operator abstract fun component1(): L?
     operator abstract fun component2(): R?
 

--- a/src/main/kotlin/org/funktionale/either/Either.kt
+++ b/src/main/kotlin/org/funktionale/either/Either.kt
@@ -29,6 +29,11 @@ import org.funktionale.utils.hashCodeForNullable
  */
 sealed class Either<out L, out R> : EitherLike {
 
+    companion object {
+        fun <L> left(left: L): Either<L, Nothing> = Left(left)
+        fun <R> right(right: R): Either<Nothing, R> = Right(right)
+    }
+
     fun left(): LeftProjection<L, R> = LeftProjection(this)
     fun right(): RightProjection<L, R> = RightProjection(this)
 

--- a/src/test/kotlin/org/funktionale/validation/ValidationTest.kt
+++ b/src/test/kotlin/org/funktionale/validation/ValidationTest.kt
@@ -1,4 +1,5 @@
 
+import org.funktionale.either.Disjunction
 import org.funktionale.either.Disjunction.*
 import org.funktionale.validation.Validation
 import org.funktionale.validation.validate
@@ -33,21 +34,21 @@ class ValidationTest {
 
     @Test
     fun validate2Test() {
-        val r1 = Right<String, Int>(1)
-        val r2 = Right<String, String>("blahblah")
-        val l1 = Left<String, Int>("fail1")
-        val l2 = Left<String, String>("fail2")
+        val r1 = Disjunction.right(1)
+        val r2 = Disjunction.right("blahblah")
+        val l1 = Disjunction.left("fail1")
+        val l2 = Disjunction.left("fail2")
         assertEquals(
                 validate(r1, r2, ::ExampleForValidation),
-                Right<List<String>, ExampleForValidation>(ExampleForValidation(1, "blahblah"))
+                Disjunction.right(ExampleForValidation(1, "blahblah"))
         )
         assertEquals(
                 validate(r1, l2, ::ExampleForValidation),
-                Left<List<String>, ExampleForValidation>(listOf("fail2"))
+                Disjunction.left(listOf("fail2"))
         )
         assertEquals(
                 validate(l1, l2, ::ExampleForValidation),
-                Left<List<String>, ExampleForValidation>(listOf("fail1", "fail2"))
+                Disjunction.left(listOf("fail1", "fail2"))
         )
     }
 }


### PR DESCRIPTION
The constructor allow creating left and right values without having to explicitly specify type parameters. Check the modified test for an example.