### PR TITLE
Try.onEach

### DIFF
--- a/funktionale-try/src/main/kotlin/org/funktionale/tries/Try.kt
+++ b/funktionale-try/src/main/kotlin/org/funktionale/tries/Try.kt
@@ -50,6 +50,11 @@ sealed class Try<T> {
         if (isSuccess()) f(get())
     }
 
+    fun onEach(f: (T) -> Unit): Try<T> = map {
+        f(it)
+        it
+    }
+
     fun <X> flatMap(f: (T) -> Try<X>): Try<X> = when (this) {
         is Success -> try {
             f(get())

--- a/funktionale-try/src/test/kotlin/org/funktionale/tries/TryTest.kt
+++ b/funktionale-try/src/test/kotlin/org/funktionale/tries/TryTest.kt
@@ -59,6 +59,11 @@ class TryTest {
         failure.foreach { fail() }
     }
 
+    @Test fun onEach() {
+        assertEquals(success.onEach { assertEquals(10, it) }.get(), 10)
+        assertTrue(failure.onEach { fail() }.isFailure())
+    }
+
     @Test fun flatMap() {
         assertEquals(success.flatMap { Success(it * 2) }.get(), 20)
         assertTrue(failure.flatMap { Success(it * 2) }.isFailure())

--- a/funktionale-try/src/test/kotlin/org/funktionale/tries/TryTest.kt
+++ b/funktionale-try/src/test/kotlin/org/funktionale/tries/TryTest.kt
@@ -16,6 +16,8 @@
 
 package org.funktionale.tries
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.funktionale.tries.Try.Failure
 import org.funktionale.tries.Try.Success
 import org.testng.Assert.*
@@ -54,14 +56,62 @@ class TryTest {
         assertEquals(failure.orElse { Success(5) }.get(), 5)
     }
 
-    @Test fun foreach() {
-        success.foreach { assertEquals(10, it) }
-        failure.foreach { fail() }
+    @Test fun `foreach with side effect (applied on Success)`() {
+        var wasInside = false
+        success.foreach { wasInside = true }
+        assertThat(wasInside).isTrue()
     }
 
-    @Test fun onEach() {
-        assertEquals(success.onEach { assertEquals(10, it) }.get(), 10)
-        assertTrue(failure.onEach { fail() }.isFailure())
+    @Test fun `foreach with side effect (applied on Failure)`() {
+        var wasInside = false
+        failure.foreach { wasInside = true }
+        assertThat(wasInside).isFalse()
+    }
+
+    @Test fun `foreach with exception thrown inside (applied on Success)`() {
+        assertThatThrownBy {
+            success.foreach { throw RuntimeException("thrown inside") }
+        }.hasMessage("thrown inside")
+    }
+
+    @Test fun `foreach with exception thrown inside (applied on Failure)`() {
+        failure.foreach { throw RuntimeException("thrown inside") }
+        // and no exception should be thrown
+    }
+
+    @Test fun `onEach with side effect (applied on Success)`() {
+        var wasInside = false
+        success.onEach { wasInside = true }
+        assertThat(wasInside).isTrue()
+    }
+
+    @Test fun `onEach with side effect (applied on Failure)`() {
+        var wasInside = false
+        failure.onEach { wasInside = true }
+        assertThat(wasInside).isFalse()
+    }
+
+    @Test fun `onEach with exception thrown inside (applied on Success)`() {
+        assertThatThrownBy {
+            success.onEach { throw RuntimeException("thrown inside") }.get()
+        }.hasMessage("thrown inside")
+    }
+
+    @Test fun `onEach with exception thrown inside (applied on Failure)`() {
+        assertThatThrownBy {
+            failure.onEach { throw RuntimeException("thrown inside") }.get()
+        }.isInstanceOf(NumberFormatException::class.java)
+    }
+
+    @Test fun `onEach with change of carried value (applied on Success)`() {
+        val result = success.onEach { it * 2 }.get()
+        assertThat(result).isEqualTo(10)
+    }
+
+    @Test fun `onEach with change of carried value (applied on Failure)`() {
+        assertThatThrownBy {
+            failure.onEach { it * 2 }.get()
+        }.isInstanceOf(NumberFormatException::class.java)
     }
 
     @Test fun flatMap() {

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <version>6.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.6.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>


### PR DESCRIPTION
What I found missing in `Try` is possibility to do something on value and return it. For example:
```
Try {
   // ...
}.onEach {
   printLog(it)
}.map {
   // ...
}
```
instead of
```
Try {
   // ...
}.map {
   printLog(it)
   it
}.map {
   // ...
}
```