### PR TITLE
added funktionale-either-without-option

### DIFF
--- a/funktionale-either-without-option/pom.xml
+++ b/funktionale-either-without-option/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Original work Copyright 2013 - 2016 Mario Arias
+  ~ Modified work Copyright 2017 - 2018 Petter Ljungqvist [Houston Inc.]
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ 	http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>funktionale</artifactId>
+        <groupId>org.funktionale</groupId>
+        <version>1.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Either and Disjunction Module</name>
+    <artifactId>funktionale-either-without-option</artifactId>
+    <packaging>jar</packaging>
+    <version>1.2</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.funktionale</groupId>
+            <artifactId>funktionale-collections</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.funktionale</groupId>
+            <artifactId>funktionale-utils</artifactId>
+            <version>1.2</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/Disjunction.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/Disjunction.kt
@@ -1,0 +1,155 @@
+/*
+ * Original work Copyright 2013 - 2016 Mario Arias
+ * Modified work Copyright 2017 Petter Ljungqvist [Houston Inc.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+import org.funktionale.collections.prependTo
+import org.funktionale.utils.hashCodeForNullable
+import java.util.*
+
+sealed class Disjunction<out L, out R> : EitherLike {
+
+    companion object {
+        fun <L> left(left: L): Left<L, Nothing> = Left(left)
+        fun <R> right(right: R): Right<Nothing, R> = Right(right)
+    }
+
+    operator abstract fun component1(): L?
+    operator abstract fun component2(): R?
+
+    fun swap(): Disjunction<R, L> = when (this) {
+        is Right -> Left(value)
+        is Left -> Right(value)
+    }
+
+    fun <X> fold(fl: (L) -> X, fr: (R) -> X): X = when (this) {
+        is Right -> fr(value)
+        is Left -> fl(value)
+    }
+
+    fun get(): R = when (this) {
+        is Right -> value
+        is Left -> throw NoSuchElementException("Disjunction.Left")
+    }
+
+    fun forEach(f: (R) -> Unit) {
+        when (this) {
+            is Right -> f(value)
+        }
+    }
+
+    fun exists(predicate: (R) -> Boolean): Boolean = when (this) {
+        is Right -> predicate(value)
+        is Left -> false
+    }
+
+    fun <X> map(f: (R) -> X): Disjunction<L, X> = when (this) {
+        is Right -> Right(f(value))
+        is Left -> Left(value)
+    }
+
+
+    fun filter(predicate: (R) -> Boolean): Disjunction<L, R>? = when (this) {
+        is Right -> this.takeIf { predicate(value) }
+        is Left -> null
+    }
+
+    fun toList(): List<R> = when (this) {
+        is Right -> listOf(value)
+        is Left -> listOf()
+    }
+
+    fun getOrNull(): R? = when (this) {
+        is Right -> value
+        is Left -> null
+    }
+
+    fun toEither(): Either<L, R> = when (this) {
+        is Right -> Either.Right(value)
+        is Left -> Either.Left(value)
+    }
+
+    class Left<out L, out R>(val value: L) : Disjunction<L, R>(), LeftLike {
+        override fun component1(): L = value
+        override fun component2(): R? = null
+        override fun equals(other: Any?): Boolean = when (other) {
+            is Left<*, *> -> value == other.value
+            else -> false
+        }
+
+        override fun hashCode(): Int = value.hashCodeForNullable(43) { a, b -> a * b }
+
+        override fun toString(): String = "Disjunction.Left($value)"
+
+
+    }
+
+    class Right<out L, out R>(val value: R) : Disjunction<L, R>(), RightLike {
+        override fun component1(): L? = null
+        override fun component2(): R = value
+
+        override fun equals(other: Any?): Boolean = when (other) {
+            is Right<*, *> -> value == other.value
+            else -> false
+        }
+
+        override fun hashCode(): Int = value.hashCodeForNullable(43) { a, b -> a * b }
+
+        override fun toString(): String = "Disjunction.Right($value)"
+
+
+    }
+}
+
+inline fun <T> disjunctionTry(body: () -> T): Disjunction<Throwable, T> = try {
+    Disjunction.Right(body())
+} catch (t: Throwable) {
+    Disjunction.Left(t)
+}
+
+fun <T> Disjunction<T, T>.merge(): T = when (this) {
+    is Disjunction.Right -> value
+    is Disjunction.Left -> value
+}
+
+fun <L, R> Disjunction<L, R>.getOrElse(default: () -> R): R = when (this) {
+    is Disjunction.Right -> value
+    is Disjunction.Left -> default()
+}
+
+fun <X, L, R> Disjunction<L, R>.flatMap(f: (R) -> Disjunction<L, X>): Disjunction<L, X> = when (this) {
+    is Disjunction.Right -> f(value)
+    is Disjunction.Left -> Disjunction.Left(value)
+}
+
+fun <L, R, X, Y> Disjunction<L, R>.map(x: Disjunction<L, X>, f: (R, X) -> Y): Disjunction<L, Y> = flatMap { r -> x.map { xx -> f(r, xx) } }
+
+fun <T, L, R> List<T>.disjuntionTraverse(f: (T) -> Disjunction<L, R>): Disjunction<L, List<R>> = foldRight(Disjunction.Right(emptyList())) { i: T, accumulator: Disjunction<L, List<R>> ->
+    val disjunction = f(i)
+    when (disjunction) {
+        is Disjunction.Right -> disjunction.map(accumulator) { head: R, tail: List<R> ->
+            head prependTo tail
+        }
+        is Disjunction.Left -> Disjunction.Left(disjunction.value)
+    }
+}
+
+fun <L, R> List<Disjunction<L, R>>.disjunctionSequential(): Disjunction<L, List<R>> = disjuntionTraverse { it }
+
+inline fun <X, T> T?.toDisjunctionRight(left: () -> X): Disjunction<X, T> = toEitherRight(left).toDisjunction()
+
+inline fun <X, T> T?.toDisjunctionLeft(right: () -> X): Disjunction<T, X> = toEitherLeft(right).toDisjunction()

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/Either.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/Either.kt
@@ -1,0 +1,116 @@
+/*
+ * Original work Copyright 2013 - 2016 Mario Arias
+ * Modified work Copyright 2017 Petter Ljungqvist [Houston Inc.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+import org.funktionale.collections.prependTo
+import org.funktionale.either.Either.Left
+import org.funktionale.either.Either.Right
+import org.funktionale.utils.hashCodeForNullable
+
+sealed class Either<out L, out R> : EitherLike {
+
+    companion object {
+        fun <L> left(left: L): Left<L, Nothing> = Left(left)
+        fun <R> right(right: R): Right<Nothing, R> = Right(right)
+    }
+
+    fun left(): LeftProjection<L, R> = LeftProjection(this)
+    fun right(): RightProjection<L, R> = RightProjection(this)
+
+    operator abstract fun component1(): L?
+    operator abstract fun component2(): R?
+
+    fun toDisjunction(): Disjunction<L, R> = when (this) {
+        is Right -> Disjunction.Right(r)
+        is Left -> Disjunction.Left(l)
+    }
+
+    fun <X> fold(fl: (L) -> X, fr: (R) -> X): X = when (this) {
+        is Left -> fl(l)
+        is Right -> fr(r)
+    }
+
+    fun swap(): Either<R, L> = when (this) {
+        is Left -> Right(this.l)
+        is Right -> Left(this.r)
+    }
+
+    class Left<out L, out R>(val l: L) : Either<L, R>(), LeftLike {
+        override fun component1(): L = l
+        override fun component2(): R? = null
+
+        override fun equals(other: Any?): Boolean = when (other) {
+            is Left<*, *> -> l == other.l
+            else -> false
+
+        }
+
+        override fun hashCode(): Int = l.hashCodeForNullable(43) { a, b -> a * b }
+
+        override fun toString(): String = "Either.Left($l)"
+    }
+
+    class Right<out L, out R>(val r: R) : Either<L, R>(), RightLike {
+        override fun component1(): L? = null
+        override fun component2(): R = r
+
+        override fun equals(other: Any?): Boolean = when (other) {
+            is Right<*, *> -> r == other.r
+            else -> false
+        }
+
+        override fun hashCode(): Int = r.hashCodeForNullable(43) { a, b -> a * b }
+
+        override fun toString(): String = "Either.Right($r)"
+    }
+}
+
+fun <T> Either<T, T>.merge(): T = when (this) {
+    is Left -> this.l
+    is Right -> this.r
+}
+
+fun <L, R> Pair<L, R>.toLeft(): Left<L, R> = Left(this.component1())
+
+fun <L, R> Pair<L, R>.toRight(): Right<L, R> = Right(this.component2())
+
+inline fun <T> eitherTry(body: () -> T): Either<Throwable, T> = try {
+    Right(body())
+} catch (t: Throwable) {
+    Left(t)
+}
+
+fun <T, L, R> List<T>.eitherTraverse(f: (T) -> Either<L, R>): Either<L, List<R>> = foldRight(Right(emptyList())) { i: T, accumulator: Either<L, List<R>> ->
+    val either = f(i)
+    when (either) {
+        is Right -> either.right().map(accumulator) { head: R, tail: List<R> ->
+            head prependTo tail
+        }
+        is Left -> Left(either.l)
+    }
+}
+
+fun <L, R> List<Either<L, R>>.eitherSequential(): Either<L, List<R>> = eitherTraverse { it: Either<L, R> -> it }
+
+inline fun <X, T> T?.toEitherRight(left: () -> X): Either<X, T> =
+        this?.let { Either.right(this) }
+                ?: Left(left())
+
+inline fun <X, T> T?.toEitherLeft(right: () -> X): Either<T, X> =
+        this?.let { Either.left(this) }
+                ?: Right(right())

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/EitherLike.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/EitherLike.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2013 - 2016 Mario Arias
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+interface EitherLike {
+    fun isLeft(): Boolean
+    fun isRight(): Boolean
+}

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/LeftLike.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/LeftLike.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 - 2016 Mario Arias
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+/**
+ * Created by IntelliJ IDEA.
+ * @author Mario Arias
+ * Date: 6/08/16
+ * Time: 12:02 AM
+ */
+interface LeftLike : EitherLike {
+    override fun isLeft(): Boolean = true
+    override fun isRight(): Boolean = false
+}

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/LeftProjection.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/LeftProjection.kt
@@ -1,0 +1,73 @@
+/*
+ * Original work Copyright 2013 - 2016 Mario Arias
+ * Modified work Copyright 2017 Petter Ljungqvist [Houston Inc.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+import org.funktionale.eithernoopt.Either.Left
+import org.funktionale.eithernoopt.Either.Right
+import java.util.*
+
+class LeftProjection<out L, out R>(val e: Either<L, R>) {
+
+    fun get(): L = when (e) {
+        is Left -> e.l
+        is Right -> throw NoSuchElementException("Either.left.value on Right")
+    }
+
+    fun forEach(f: (L) -> Unit) {
+        when (e) {
+            is Left<L, R> -> f(e.l)
+        }
+    }
+
+
+    fun exists(predicate: (L) -> Boolean): Boolean = when (e) {
+        is Left -> predicate(e.l)
+        is Right -> false
+    }
+
+
+    fun <X> map(f: (L) -> X): Either<X, R> = flatMap { Left<X, R>(f(it)) }
+
+    fun filter(predicate: (L) -> Boolean): Either<L, R>? = when (e) {
+        is Left -> e.takeIf { predicate(it.l) }
+        is Right -> null
+    }
+
+    fun toList(): List<L> = when (e) {
+        is Left -> listOf(e.l)
+        is Right -> listOf()
+    }
+
+    fun getOrNull(): L? = when (e) {
+        is Left -> e.l
+        is Right -> null
+    }
+
+}
+
+fun <L, R, X> LeftProjection<L, R>.flatMap(f: (L) -> Either<X, R>): Either<X, R> = when (e) {
+    is Left -> f(e.l)
+    is Right -> Right(e.r)
+}
+
+fun <L, R, X, Y> LeftProjection<L, R>.map(x: Either<X, R>, f: (L, X) -> Y): Either<Y, R> = flatMap { l -> x.left().map { xx -> f(l, xx) } }
+
+fun <L, R> LeftProjection<L, R>.getOrElse(default: () -> L): L = when (e) {
+    is Left -> e.l
+    is Right -> default()
+}

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/RightLike.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/RightLike.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013 - 2016 Mario Arias
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+
+interface RightLike : EitherLike {
+    override fun isLeft(): Boolean = false
+    override fun isRight(): Boolean = true
+}

--- a/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/RightProjection.kt
+++ b/funktionale-either-without-option/src/main/kotlin/org/funktionale/eithernoopt/RightProjection.kt
@@ -1,0 +1,73 @@
+/*
+ * Original work Copyright 2013 - 2016 Mario Arias
+ * Modified work Copyright 2017 Petter Ljungqvist [Houston Inc.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+import org.funktionale.eithernoopt.Either.Left
+import org.funktionale.eithernoopt.Either.Right
+import java.util.*
+
+class RightProjection<out L, out R>(val e: Either<L, R>) {
+
+    fun get(): R = when (e) {
+        is Right -> e.r
+        is Left -> throw NoSuchElementException("Either.right.value on Left")
+    }
+
+    fun forEach(f: (R) -> Unit) {
+        when (e) {
+            is Right -> f(e.r)
+        }
+    }
+
+
+    fun exists(predicate: (R) -> Boolean): Boolean = when (e) {
+        is Right -> predicate(e.r)
+        is Left -> false
+    }
+
+    fun <X> map(f: (R) -> X): Either<L, X> = flatMap { Right<L, X>(f(it)) }
+
+    fun filter(predicate: (R) -> Boolean): Either<L, R>? = when (e) {
+        is Right -> e.takeIf { predicate(it.r) }
+        is Left -> null
+    }
+
+    fun toList(): List<R> = when (e) {
+        is Right -> listOf(e.r)
+        is Left -> listOf()
+    }
+
+    fun getOrNull(): R? = when (e) {
+        is Right -> e.r
+        is Left -> null
+    }
+
+}
+
+fun <L, R> RightProjection<L, R>.getOrElse(default: () -> R): R = when (e) {
+    is Right -> e.r
+    is Left -> default()
+}
+
+fun <X, L, R> RightProjection<L, R>.flatMap(f: (R) -> Either<L, X>): Either<L, X> = when (e) {
+    is Left -> Left(e.l)
+    is Right -> f(e.r)
+}
+
+
+fun <L, R, X, Y> RightProjection<L, R>.map(x: Either<L, X>, f: (R, X) -> Y): Either<L, Y> = flatMap { r -> x.right().map { xx -> f(r, xx) } }

--- a/funktionale-either-without-option/src/test/kotlin/org/funktionale/eithernoopt/DisjunctionTest.kt
+++ b/funktionale-either-without-option/src/test/kotlin/org/funktionale/eithernoopt/DisjunctionTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Original work Copyright 2013 - 2016 Mario Arias
+ * Modified work Copyright 2017 Petter Ljungqvist [Houston Inc.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+import org.funktionale.eithernoopt.*
+import org.funktionale.eithernoopt.Disjunction.Left
+import org.funktionale.eithernoopt.Disjunction.Right
+import org.testng.Assert.*
+import org.testng.annotations.Test
+
+
+class DisjunctionTest {
+
+
+    private val left = Disjunction.left(5)
+    private val right = Disjunction.right("kotlin")
+
+    @Test fun get() {
+        assertEquals(left.swap().get(), 5)
+        assertEquals(right.get(), "kotlin")
+    }
+
+    //[Test(expectedExceptions = array(javaClass<NoSuchElementException>()))]
+
+    @Test fun getWithException() {
+        try {
+            assertEquals(right.swap().get(), 5)
+            fail()
+        } catch(e: Exception) {
+            //expected
+        }
+        try {
+            assertEquals(left.get(), "kotlin")
+            fail()
+        } catch(e: Exception) {
+            //Expected
+        }
+    }
+
+    @Test fun forEach() {
+        left.swap().forEach {
+            assertEquals(it * 2, 10)
+        }
+
+        right.forEach {
+            assertEquals(it.length, 6)
+        }
+    }
+
+    @Test fun getOrElse() {
+        assertEquals(left.swap().getOrElse { 2 }, 5)
+        assertEquals(left.getOrElse { "java" }, "java")
+    }
+
+    @Test fun exists() {
+        assertTrue(left.swap().exists { it == 5 })
+        assertFalse(left.exists { it == "kotlin" })
+    }
+
+    @Test fun flatMap() {
+        assertEquals(left.swap().flatMap { Left<String, Int>(it.toString()) }.swap().get(), "5")
+        assertEquals(right.flatMap { Right<String, Int>(it.length) }.get(), 6)
+    }
+
+    @Test fun map() {
+        assertEquals(left.swap().map(Int::toString).get(), "5")
+        assertEquals(right.map { it.length }.get(), 6)
+    }
+
+    @Test fun filter() {
+        assertEquals(left.swap().filter { it == 5 }?.get(), 5)
+        assertNull(left.swap().filter { it == 6 })
+        assertEquals(right.filter { it.startsWith('k') }?.get(), "kotlin")
+        assertNull(right.filter { it.startsWith('j') })
+    }
+
+    @Test fun toList() {
+        assertEquals(left.swap().toList(), listOf(5))
+        assertEquals(left.toList(), listOf<Int>())
+    }
+
+    @Test fun toOption() {
+        assertEquals(left.swap().getOrNull(), 5)
+        assertNull(left.getOrNull())
+    }
+
+    @Test fun fold() {
+        assertEquals(left.fold(Int::toString, { it }), "5")
+    }
+
+    @Test fun swap() {
+        assertEquals(left.swap().get(), 5)
+        assertEquals(right.swap().swap().get(), "kotlin")
+    }
+
+    @Test fun components() {
+        val (aInt, aNullString) = left
+        assertNotNull(aInt)
+        assertNull(aNullString)
+
+        val (aNullInt, aString) = right
+        assertNull(aNullInt)
+        assertNotNull(aString)
+    }
+
+    @Test fun merge() {
+        assertEquals(left.merge(), 5)
+        assertEquals(right.merge(), "kotlin")
+    }
+
+    @Test fun disjunctionTry() {
+        val e: Disjunction<Throwable, Nothing> = org.funktionale.eithernoopt.disjunctionTry {
+            throw RuntimeException()
+        }
+        assertTrue(e.isLeft())
+    }
+
+    @Test fun sequential() {
+        fun parseInts(ints: List<String>): Disjunction<Throwable, List<Int>> {
+            return ints.map { org.funktionale.eithernoopt.disjunctionTry { it.toInt() } }.disjunctionSequential()
+        }
+
+        assertEquals(parseInts(listOf("1", "2", "3")), Right<Exception, List<Int>>(listOf(1, 2, 3)))
+        assertTrue(parseInts(listOf("1", "foo", "3")) is Left)
+    }
+}

--- a/funktionale-either-without-option/src/test/kotlin/org/funktionale/eithernoopt/EitherTest.kt
+++ b/funktionale-either-without-option/src/test/kotlin/org/funktionale/eithernoopt/EitherTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Original work Copyright 2013 - 2016 Mario Arias
+ * Modified work Copyright 2017 Petter Ljungqvist [Houston Inc.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.funktionale.eithernoopt
+
+import org.funktionale.eithernoopt.*
+import org.funktionale.eithernoopt.Either.Left
+import org.funktionale.eithernoopt.Either.Right
+import org.testng.Assert.*
+import org.testng.annotations.Test
+
+/**
+ * Created by IntelliJ IDEA.
+ * @author Mario Arias
+ * Date: 17/05/13
+ * Time: 21:53
+ */
+class EitherTest {
+
+    val pair = 5 to "kotlin"
+    val left = pair.toLeft()
+    val right = pair.toRight()
+
+    @Test fun get() {
+        assertEquals(left.left().get(), 5)
+        assertEquals(right.right().get(), "kotlin")
+    }
+
+    //[Test(expectedExceptions = array(javaClass<NoSuchElementException>()))]
+
+    @Test fun getWithException() {
+        try {
+            assertEquals(right.left().get(), 5)
+            fail()
+        } catch(e: Exception) {
+            //expected
+        }
+        try {
+            assertEquals(left.right().get(), "kotlin")
+            fail()
+        } catch(e: Exception) {
+            //Expected
+        }
+    }
+
+    @Test fun forEach() {
+        left.left().forEach {
+            assertEquals(it * 2, 10)
+        }
+
+        right.right().forEach {
+            assertEquals(it.length, 6)
+        }
+    }
+
+    @Test fun getOrElse() {
+        assertEquals(left.left().getOrElse { 2 }, 5)
+        assertEquals(left.right().getOrElse { "java" }, "java")
+    }
+
+    @Test fun exists() {
+        assertTrue(left.left().exists { it == 5 })
+        assertFalse(left.right().exists { it == "kotlin" })
+    }
+
+    @Test fun flatMap() {
+        assertEquals(left.left().flatMap { Left<String, Int>(it.toString()) }.left().get(), "5")
+        assertEquals(right.right().flatMap { Right<String, Int>(it.length) }.right().get(), 6)
+    }
+
+    @Test fun map() {
+        assertEquals(left.left().map(Int::toString).left().get(), "5")
+        assertEquals(right.right().map { it.length }.right().get(), 6)
+    }
+
+    @Test fun filter() {
+        assertEquals(left.left().filter { it == 5 }?.left()?.get(), 5)
+        assertNull(left.left().filter { it == 6 })
+        assertEquals(right.right().filter { it.startsWith('k') }?.right()?.get(), "kotlin")
+        assertNull(right.right().filter { it.startsWith('j') })
+    }
+
+    @Test fun toList() {
+        assertEquals(left.left().toList(), listOf(5))
+        assertEquals(left.right().toList(), listOf<Int>())
+    }
+
+    @Test fun toOption() {
+        assertEquals(left.left().getOrNull(), 5)
+        assertNull(left.right().getOrNull())
+    }
+
+    @Test fun fold() {
+        assertEquals(left.fold(Int::toString) { it }, "5")
+    }
+
+    @Test fun swap() {
+        assertEquals(left.swap().right().get(), 5)
+        assertEquals(right.swap().left().get(), "kotlin")
+    }
+
+    @Test fun components() {
+        val (aInt, aNullString) = left
+        assertNotNull(aInt)
+        assertNull(aNullString)
+
+        val (aNullInt, aString) = right
+        assertNull(aNullInt)
+        assertNotNull(aString)
+    }
+
+    @Test fun merge() {
+        assertEquals(left.merge(), 5)
+        assertEquals(right.merge(), "kotlin")
+    }
+
+    @Test fun either() {
+        val e: Either<Throwable, Nothing> = eitherTry {
+            throw RuntimeException()
+        }
+        assertTrue(e.isLeft())
+    }
+
+    @Test fun sequential() {
+        fun parseInts(ints: List<String>): Either<Throwable, List<Int>> {
+            return ints.map { eitherTry { it.toInt() } }.eitherSequential()
+        }
+
+        assertEquals(parseInts(listOf("1", "2", "3")), Right<Exception, List<Int>>(listOf(1, 2, 3)))
+        assertTrue(parseInts(listOf("1", "foo", "3")) is Left)
+    }
+
+    val some: String? = "kotlin"
+    val none: String? = null
+
+    @Test fun toRight() {
+        assertTrue(some.toEitherRight { 0 }.isRight())
+        assertFalse(none.toEitherRight { 0 }.isRight())
+    }
+
+
+    @Test fun toLeft() {
+        assertTrue(some.toEitherLeft { 0 }.isLeft())
+        assertFalse(none.toEitherLeft { 0 }.isLeft())
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>funktionale-utils</module>
         <module>funktionale-option</module>
         <module>funktionale-either</module>
+        <module>funktionale-either-without-option</module>
         <module>funktionale-validation</module>
         <module>funktionale-try</module>
         <module>funktionale-state</module>


### PR DESCRIPTION
A version of `funktionale-either` using Kotlins "nullable" instead of `funktionale-option`.