### PR TITLE
Include only org.funktionale.* in fat jar for funktionale-all package (Fixes #42)

### DIFF
--- a/funktionale-all/pom.xml
+++ b/funktionale-all/pom.xml
@@ -125,9 +125,9 @@
                         </goals>
                         <configuration>
                             <artifactSet>
-                                <excludes>
-                                    <exclude>org.jetbrains.kotlin:*</exclude>
-                                </excludes>
+                                <includes>
+                                    <include>org/funktionale/**</include>
+                                </includes>
                             </artifactSet>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This is an attempt to fix #42. 

Instead of adding more excludes to remove unwanted libraries (JetBrains annotations and IntelliJ annotations), I've specified that only the contents of the `org.funktionale` package should be included in it - this is easier than having to maintain a list of excluded libraries, even if development has now halted in favor of Arrow.

I couldn't figure out how to build the project locally, but I hope this solution works.