### PR TITLE
Reference Arrow in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ funKTionale
 Functional constructs and patterns for [Kotlin](http://kotlin-lang.org)
 
 *NOTE: Development of this project is frozen*, as it will eventually be made obsolete by 
-[Arrow](arrow-kt.io), which merges the functionality of funKTionale and [Kategory](https://github.com/47deg/kategory-intro). If you are not yet using funKTionale, we recommend you [start with Arrow](http://arrow-kt.io/docs/) instead.
+[Arrow](https://arrow-kt.io/), which merges the functionality of funKTionale and [Kategory](https://github.com/47deg/kategory-intro). If you are not yet using funKTionale, we recommend you [start with Arrow](https://arrow-kt.io/docs/) instead.
 
 ## Modules
 
@@ -61,5 +61,4 @@ Then you can use any funKTionale module to your library
 ## How to contribute?
 
 Rise your PR against Experimental module (`funktionale-experimental`). Once it gets approved I'll move it to a proper module 
-
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ funKTionale
 
 Functional constructs and patterns for [Kotlin](http://kotlin-lang.org)
 
+*NOTE: Development of this project is frozen*, as it will eventually be made obsolete by 
+[Arrow](arrow-kt.io), which merges the functionality of funKTionale and [Kategory](https://github.com/47deg/kategory-intro). If you are not yet using funKTionale, we recommend you [start with Arrow](http://arrow-kt.io/docs/) instead.
+
 ## Modules
 
 | Module | Description | Internal Dependencies | Size(KB) |


### PR DESCRIPTION
A little README change to help future travellers - I had started using funKTionale before realizing that Arrow existed, and is intended to replace funKTionale. Hopefully the note I have added here will save others some time.